### PR TITLE
Add waiting close channels to channels list

### DIFF
--- a/Library/Extensions/Localizable/ChannelState+Localizable.swift
+++ b/Library/Extensions/Localizable/ChannelState+Localizable.swift
@@ -21,6 +21,8 @@ extension ChannelState: Localizable {
             return L10n.Channel.State.closing
         case .forceClosing:
             return L10n.Channel.State.forceClosing
+        case .waitingClose:
+            return L10n.Channel.State.waitingClose
         }
     }
 }

--- a/Library/Generated/strings.swift
+++ b/Library/Generated/strings.swift
@@ -24,6 +24,8 @@ internal enum L10n {
       internal static let inactive = L10n.tr("Localizable", "channel.state.inactive")
       /// Opening
       internal static let opening = L10n.tr("Localizable", "channel.state.opening")
+      /// Waiting Close
+      internal static let waitingClose = L10n.tr("Localizable", "channel.state.waiting_close")
     }
   }
 

--- a/Library/Scenes/ChannelList/ChannelDetailViewController.swift
+++ b/Library/Scenes/ChannelList/ChannelDetailViewController.swift
@@ -11,33 +11,33 @@ import SwiftLnd
 final class ChannelDetailViewController: ModalDetailViewController {
     let channelViewModel: ChannelViewModel
     let channelListViewModel: ChannelListViewModel
-    
+
     var presentBlockExplorer: (String, BlockExplorer.CodeType) -> Void
-    
+
     init(channelViewModel: ChannelViewModel, channelListViewModel: ChannelListViewModel, blockExplorerButtonTapped: @escaping (String, BlockExplorer.CodeType) -> Void) {
         self.channelViewModel = channelViewModel
         self.channelListViewModel = channelListViewModel
         self.presentBlockExplorer = blockExplorerButtonTapped
-        
+
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         setupStackView(channelViewModel)
     }
-    
+
     func setupStackView(_ channelViewModel: ChannelViewModel) {
         addHeadline(channelViewModel.name.value)
-        
+
         let labelStyle = Style.Label.headline
         let textStyle = Style.Label.body
-        
+
         if channelViewModel.channel.state.isClosing {
             contentStackView.addArrangedElement(.horizontalStackView(compressionResistant: .first, content: [
                 .label(text: L10n.Scene.ChannelDetail.ClosingTime.label + ":", style: labelStyle),
@@ -45,30 +45,32 @@ final class ChannelDetailViewController: ModalDetailViewController {
             ]))
             contentStackView.addArrangedElement(.separator)
         }
-        
+
         contentStackView.addArrangedElement(.verticalStackView(content: [
             .label(text: L10n.Scene.ChannelDetail.remotePubKeyLabel + ":", style: labelStyle),
             .label(text: channelViewModel.channel.remotePubKey, style: textStyle)
         ], spacing: 0))
-        
-        contentStackView.addArrangedElement(.separator)
-        let balanceView = BalanceView()
-        balanceView.set(localBalance: channelViewModel.channel.localBalance, remoteBalance: channelViewModel.channel.remoteBalance)
-        
-        contentStackView.addArrangedElement(.verticalStackView(content: [
-            .customHeight(10, element: .customView(balanceView)),
-            .horizontalStackView(compressionResistant: .first, content: [
-                .customView(circleIndicatorView(gradient: [UIColor.Zap.lightningOrange, UIColor.Zap.lightningOrangeGradient])),
-                .label(text: L10n.Scene.ChannelDetail.localBalanceLabel + ":", style: labelStyle),
-                .amountLabel(amount: channelViewModel.channel.localBalance, style: textStyle)
-            ]),
-            .horizontalStackView(compressionResistant: .first, content: [
-                .customView(circleIndicatorView(gradient: [UIColor.Zap.white, UIColor.Zap.white])),
-                .label(text: L10n.Scene.ChannelDetail.remoteBalanceLabel + ":", style: labelStyle),
-                .amountLabel(amount: channelViewModel.channel.remoteBalance, style: textStyle)
-            ])
-        ], spacing: 5))
-        
+
+        if channelViewModel.channel.state != ChannelState.waitingClose {
+            contentStackView.addArrangedElement(.separator)
+            let balanceView = BalanceView()
+            balanceView.set(localBalance: channelViewModel.channel.localBalance, remoteBalance: channelViewModel.channel.remoteBalance)
+
+            contentStackView.addArrangedElement(.verticalStackView(content: [
+                .customHeight(10, element: .customView(balanceView)),
+                .horizontalStackView(compressionResistant: .first, content: [
+                    .customView(circleIndicatorView(gradient: [UIColor.Zap.lightningOrange, UIColor.Zap.lightningOrangeGradient])),
+                    .label(text: L10n.Scene.ChannelDetail.localBalanceLabel + ":", style: labelStyle),
+                    .amountLabel(amount: channelViewModel.channel.localBalance, style: textStyle)
+                ]),
+                .horizontalStackView(compressionResistant: .first, content: [
+                    .customView(circleIndicatorView(gradient: [UIColor.Zap.white, UIColor.Zap.white])),
+                    .label(text: L10n.Scene.ChannelDetail.remoteBalanceLabel + ":", style: labelStyle),
+                    .amountLabel(amount: channelViewModel.channel.remoteBalance, style: textStyle)
+                ])
+            ], spacing: 5))
+        }
+
         contentStackView.addArrangedElement(.separator)
         let fundingTxId = channelViewModel.channel.channelPoint.fundingTxid
         contentStackView.addArrangedElement(.horizontalStackView(compressionResistant: .first, content: [
@@ -80,33 +82,33 @@ final class ChannelDetailViewController: ModalDetailViewController {
                 })
             }
         ]))
-        
+
         if !channelViewModel.channel.state.isClosing {
             let closeTitle = channelViewModel.channel.state == .active ? L10n.Scene.ChannelDetail.closeButton : L10n.Scene.ChannelDetail.forceCloseButton
-            
+
             contentStackView.addArrangedElement(.separator)
             contentStackView.addArrangedElement(.button(title: closeTitle, style: Style.Button.custom(fontSize: 20)) { [weak self] _ in self?.closeChannel() })
         }
     }
-    
+
     private func circleIndicatorView(gradient: [UIColor]) -> UIView {
         let localIndicator = GradientView()
         localIndicator.constrainSize(to: CGSize(width: 10, height: 10))
         localIndicator.layer.cornerRadius = 5
         localIndicator.gradient = gradient
-        
+
         let localIndicatorContainer = UIView()
         localIndicatorContainer.addAutolayoutSubview(localIndicator)
         localIndicatorContainer.constrainCenter(to: localIndicator)
-        
+
         NSLayoutConstraint.activate([
             localIndicator.leadingAnchor.constraint(equalTo: localIndicatorContainer.leadingAnchor),
             localIndicator.trailingAnchor.constraint(equalTo: localIndicatorContainer.trailingAnchor)
         ])
-        
+
         return localIndicatorContainer
     }
-    
+
     private func closeChannel() {
         let alertController = UIAlertController.closeChannelAlertController(channelViewModel: channelViewModel) { [channelViewModel, weak self] in
             let loadingView = self?.presentLoadingView(text: L10n.Scene.Channels.closeLoadingView)
@@ -118,10 +120,10 @@ final class ChannelDetailViewController: ModalDetailViewController {
         }
         self.present(alertController, animated: true)
     }
-    
+
     private func dismissAfterClose(result: Result<CloseStatusUpdate>, loadingView: LoadingView?) {
         loadingView?.removeFromSuperview()
-        
+
         switch result {
         case .success:
             dismiss(animated: true) {

--- a/Library/Scenes/ChannelList/ChannelDetailViewController.swift
+++ b/Library/Scenes/ChannelList/ChannelDetailViewController.swift
@@ -38,7 +38,7 @@ final class ChannelDetailViewController: ModalDetailViewController {
         let labelStyle = Style.Label.headline
         let textStyle = Style.Label.body
 
-        if channelViewModel.channel.state.isClosing {
+        if channelViewModel.channel.state == .closing || channelViewModel.channel.state == .forceClosing {
             contentStackView.addArrangedElement(.horizontalStackView(compressionResistant: .first, content: [
                 .label(text: L10n.Scene.ChannelDetail.ClosingTime.label + ":", style: labelStyle),
                 .label(text: channelViewModel.csvDelayTimeString, style: textStyle)

--- a/Library/Scenes/ChannelList/ChannelListViewModel.swift
+++ b/Library/Scenes/ChannelList/ChannelListViewModel.swift
@@ -25,6 +25,8 @@ extension ChannelState: Comparable {
             return 3
         case .inactive:
             return 4
+        case .waitingClose:
+            return 5
         }
     }
     

--- a/Library/en.lproj/Localizable.strings
+++ b/Library/en.lproj/Localizable.strings
@@ -22,6 +22,7 @@
 "channel.state.opening" = "Opening";
 "channel.state.closing" = "Closing";
 "channel.state.force_closing" = "Force Closing";
+"channel.state.waiting_close" = "Waiting Close";
 
 "network_type.regtest" = "Regtest";
 "network_type.testnet" = "Testnet";

--- a/SwiftLnd/Model/Channel.swift
+++ b/SwiftLnd/Model/Channel.swift
@@ -15,10 +15,11 @@ public enum ChannelState {
     case opening
     case closing
     case forceClosing
+    case waitingClose
     
     public var isClosing: Bool {
         switch self {
-        case .closing, .forceClosing:
+        case .closing, .forceClosing, .waitingClose:
             return true
         default:
            return false
@@ -59,7 +60,8 @@ extension LNDPendingChannelsResponse {
         let pendingOpenChannels: [Channel] = pendingOpenChannelsArray.compactMap { ($0 as! LNDPendingChannelsResponse_PendingOpenChannel).channelModel }
         let pendingClosingChannels: [Channel] = pendingClosingChannelsArray.compactMap { ($0 as! LNDPendingChannelsResponse_ClosedChannel).channelModel }
         let pendingForceClosingChannels: [Channel] = pendingForceClosingChannelsArray.compactMap { ($0 as! LNDPendingChannelsResponse_ForceClosedChannel).channelModel }
-        return pendingOpenChannels + pendingClosingChannels + pendingForceClosingChannels
+        let waitingCloseChannels: [Channel] = waitingCloseChannelsArray.compactMap { ($0 as! LNDPendingChannelsResponse_WaitingCloseChannel).channelModel }
+        return pendingOpenChannels + pendingClosingChannels + pendingForceClosingChannels + waitingCloseChannels
     }
 }
 
@@ -105,5 +107,20 @@ extension LNDPendingChannelsResponse_ForceClosedChannel {
             updateCount: 0,
             channelPoint: ChannelPoint(string: channel.channelPoint),
             csvDelay: Int(blocksTilMaturity))
+    }
+}
+
+extension LNDPendingChannelsResponse_WaitingCloseChannel {
+    var channelModel: Channel {
+        return Channel(
+                blockHeight: nil,
+                state: .waitingClose,
+                localBalance: Satoshi(channel.localBalance),
+                remoteBalance: Satoshi(channel.remoteBalance),
+                remotePubKey: channel.remoteNodePub,
+                capacity: Satoshi(channel.capacity),
+                updateCount: 0,
+                channelPoint: ChannelPoint(string: channel.channelPoint),
+                csvDelay: 144)
     }
 }


### PR DESCRIPTION
Channels in the waiting close state are stuck in the mempool awaiting confimation. This is why the local and remote balance is unconfirmed.

## Description
- Channels from waiting close are added to the pending channels response.
- New channel state: .waitingClose
- Simplified view of a channel in .waitingClose because local balance and remote balance is undefined.
- ETA for when the channel is closed is also undefined because the transaction goes into the mempool, but it will be at least 144 blocks 

## Motivation and Context
Fixes: https://github.com/LN-Zap/zap-iOS/issues/70

## How Has This Been Tested?
Tested in app connected to mainnet

## Screenshots (if appropriate):
With mock data
![img_1077](https://user-images.githubusercontent.com/1461461/51768115-ac2df680-20df-11e9-9d76-420227f30493.jpg)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.