### PR TITLE
Add fee selector to open channel

### DIFF
--- a/Library/Generated/strings.swift
+++ b/Library/Generated/strings.swift
@@ -330,6 +330,12 @@ internal enum L10n {
       internal static let addButton = L10n.tr("Localizable", "scene.open_channel.add_button")
       /// Node:
       internal static let channelUriLabel = L10n.tr("Localizable", "scene.open_channel.channel_uri_label")
+      /// Estimated confimation time: %@
+      internal static func estimatedConfirmationTime(_ p1: String) -> String {
+        return L10n.tr("Localizable", "scene.open_channel.estimated-confirmation-time", p1)
+      }
+      /// Priority:
+      internal static let priority = L10n.tr("Localizable", "scene.open_channel.priority")
       /// Open Channel
       internal static let title = L10n.tr("Localizable", "scene.open_channel.title")
       internal enum PasteButton {

--- a/Library/Scenes/OpenChannel/OpenChannelViewController.swift
+++ b/Library/Scenes/OpenChannel/OpenChannelViewController.swift
@@ -13,6 +13,7 @@ final class OpenChannelViewController: ModalDetailViewController {
 
     private weak var amountInputView: AmountInputView?
     private weak var openButton: CallbackButton?
+    private weak var channelFeePriorityView: ChannelFeePriorityView?
 
     var nodeAlias: String?
 
@@ -50,6 +51,13 @@ final class OpenChannelViewController: ModalDetailViewController {
         self.amountInputView = amountInputView
 
         contentStackView.addArrangedSubview(amountInputView)
+
+        contentStackView.addArrangedElement(.separator)
+
+        let channelFeeView = ChannelFeePriorityView()
+        channelFeeView.delegate = self
+        contentStackView.addArrangedElement(.customView(channelFeeView))
+        self.channelFeePriorityView = channelFeeView
 
         openButton = contentStackView.addArrangedElement(.customHeight(56, element: .button(title: L10n.Scene.OpenChannel.addButton, style: Style.Button.background, completion: { [weak self] button in
             self?.openChannel()
@@ -92,5 +100,19 @@ final class OpenChannelViewController: ModalDetailViewController {
 
     @objc private func updateAmount(_ sender: AmountInputView) {
         viewModel.amount = sender.satoshis
+    }
+}
+
+extension OpenChannelViewController: ChannelFeePriorityViewDelegate {
+    func confirmationTargetChanged(to confirmationTarget: Int) {
+        viewModel.confirmationTarget = confirmationTarget
+    }
+
+    func didChangeSize(expanded: Bool) {
+        if expanded {
+            channelFeePriorityView?.resignFirstResponder()
+        }
+
+        updateHeight()
     }
 }

--- a/Library/Scenes/OpenChannel/OpenChannelViewModel.swift
+++ b/Library/Scenes/OpenChannel/OpenChannelViewModel.swift
@@ -19,6 +19,8 @@ final class OpenChannelViewModel: NSObject {
     let subtitle = Observable<String?>(nil)
     let isAmountValid = Observable(true)
 
+    var confirmationTarget: Int = 0
+
     var amount: Satoshi = 100000 {
         didSet {
             updateSubtitle()
@@ -56,6 +58,6 @@ final class OpenChannelViewModel: NSObject {
     }
 
     func openChannel(completion: @escaping ApiCompletion<ChannelPoint>) {
-        lightningService.channelService.open(lightningNodeURI: lightningNodeURI, amount: amount, completion: completion)
+        lightningService.channelService.open(lightningNodeURI: lightningNodeURI, amount: amount, confirmationTarget: confirmationTarget, completion: completion)
     }
 }

--- a/Library/Views/ChannelFeePriortyView/ChannelFeePriorityView.swift
+++ b/Library/Views/ChannelFeePriortyView/ChannelFeePriorityView.swift
@@ -1,0 +1,103 @@
+//
+//  Library
+//
+//  Created by 0 on 23.05.19.
+//  Copyright © 2019 Zap. All rights reserved.
+//
+
+import Bond
+import Foundation
+import SwiftBTC
+
+protocol ChannelFeePriorityViewDelegate: class {
+    func confirmationTargetChanged(to confirmationTarget: Int)
+    func didChangeSize(expanded: Bool)
+}
+
+final class ChannelFeePriorityView: UIView {
+    @IBOutlet private var contentView: UIView!
+
+    @IBOutlet private weak var rightStackView: UIStackView!
+    @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var detailedDescriptionLabel: UILabel!
+    @IBOutlet private weak var arrowImageView: UIImageView!
+    @IBOutlet private weak var segmentedControl: UISegmentedControl!
+    @IBOutlet private weak var timeIntervalLabel: UILabel!
+    @IBOutlet private weak var bottomContainer: UIView!
+
+    private let onChainFeeViewModel = OnChainFeeViewModel()
+
+    var expanded = false {
+        didSet {
+            updateExpandedState(animated: true)
+        }
+    }
+
+    weak var delegate: ChannelFeePriorityViewDelegate?
+
+    init() {
+        super.init(frame: .zero)
+        setup()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setup() {
+        Bundle.library.loadNibNamed("OnChainFeeView", owner: self, options: nil)
+        addSubview(contentView)
+        contentView.frame = self.bounds
+        contentView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
+
+        contentView.backgroundColor = UIColor.Zap.background
+
+        Style.Label.headline.apply(to: titleLabel)
+        Style.Label.subHeadline.apply(to: detailedDescriptionLabel, timeIntervalLabel)
+
+        titleLabel.text = L10n.Scene.OpenChannel.priority
+
+        updateFeeLabels(for: 0)
+
+        for (index, title) in onChainFeeViewModel.titles.enumerated() {
+            segmentedControl.setTitle(title, forSegmentAt: index)
+        }
+
+        updateExpandedState(animated: false)
+    }
+
+    @IBAction private func toggleDetail(_ sender: Any) {
+        expanded.toggle()
+        updateExpandedState(animated: true)
+        delegate?.didChangeSize(expanded: expanded)
+    }
+
+    private func updateExpandedState(animated: Bool) {
+        let asset = expanded ? Asset.iconArrowUpSmall : Asset.iconArrowDownSmall
+        arrowImageView.image = asset.image
+
+        if animated {
+            layoutIfNeeded()
+            UIView.animate(withDuration: 0.3) { [weak self] in
+                guard let self = self else { return }
+                self.bottomContainer.isHidden = !self.expanded
+                self.layoutIfNeeded()
+            }
+        } else {
+            bottomContainer.isHidden = !expanded
+        }
+    }
+
+    @IBAction private func updateSegment(_ sender: UISegmentedControl) {
+        updateFeeLabels(for: sender.selectedSegmentIndex)
+
+        let confirmationTarget = onChainFeeViewModel.tiers[sender.selectedSegmentIndex].confirmationTarget
+        delegate?.confirmationTargetChanged(to: confirmationTarget)
+    }
+
+    private func updateFeeLabels(for index: Int) {
+        let tier = onChainFeeViewModel.tiers[index]
+        timeIntervalLabel.text = L10n.Scene.OpenChannel.estimatedConfirmationTime(tier.formattedConfirmationTimeInterval)
+        detailedDescriptionLabel.text = tier.description
+    }
+}

--- a/Library/Views/ChannelFeePriortyView/ChannelFeePriorityView.swift
+++ b/Library/Views/ChannelFeePriortyView/ChannelFeePriorityView.swift
@@ -1,7 +1,7 @@
 //
 //  Library
 //
-//  Created by 0 on 23.05.19.
+//  Created by K on 09.06.19.
 //  Copyright © 2019 Zap. All rights reserved.
 //
 

--- a/Library/Views/ChannelFeePriortyView/ChannelFeePriorityView.xib
+++ b/Library/Views/ChannelFeePriortyView/ChannelFeePriorityView.xib
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="OnChainFeeView" customModule="Library" customModuleProvider="target">
+            <connections>
+                <outlet property="arrowImageView" destination="XFZ-5C-XeS" id="Elg-0U-HmU"/>
+                <outlet property="bottomContainer" destination="pqE-KU-zYT" id="CDz-kq-8ES"/>
+                <outlet property="contentView" destination="D6e-Lh-374" id="4uI-Qa-Oxw"/>
+                <outlet property="detailedDescriptionLabel" destination="fhb-Mj-tO3" id="1dV-ml-hXg"/>
+                <outlet property="rightStackView" destination="qiM-Ct-qfS" id="tfh-Ks-acA"/>
+                <outlet property="segmentedControl" destination="9xW-FT-281" id="iCd-Hp-4tl"/>
+                <outlet property="timeIntervalLabel" destination="xAt-1R-IAG" id="uGf-Y8-Lir"/>
+                <outlet property="titleLabel" destination="kvL-Nu-sIm" id="SLg-M8-Ejt"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="D6e-Lh-374">
+            <rect key="frame" x="0.0" y="0.0" width="478" height="448"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="tet-0s-l44">
+                    <rect key="frame" x="0.0" y="44" width="478" height="404"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fLN-Ja-aXc">
+                            <rect key="frame" x="0.0" y="0.0" width="478" height="334.5"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="el7-Xy-oGp">
+                                    <rect key="frame" x="0.0" y="0.0" width="478" height="334.5"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kvL-Nu-sIm">
+                                            <rect key="frame" x="0.0" y="0.0" width="416" height="334.5"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="300" horizontalCompressionResistancePriority="1000" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="qiM-Ct-qfS">
+                                            <rect key="frame" x="421" y="0.0" width="42" height="334.5"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="300" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="Label" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fhb-Mj-tO3">
+                                                    <rect key="frame" x="0.0" y="0.0" width="42" height="334.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </stackView>
+                                        <view contentMode="scaleToFill" horizontalHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="en2-KN-5t5">
+                                            <rect key="frame" x="468" y="0.0" width="10" height="334.5"/>
+                                            <subviews>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="1000" verticalHuggingPriority="251" image="icon_arrow_down_small" translatesAutoresizingMaskIntoConstraints="NO" id="XFZ-5C-XeS">
+                                                    <rect key="frame" x="0.0" y="165.5" width="10" height="4"/>
+                                                </imageView>
+                                            </subviews>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstItem="XFZ-5C-XeS" firstAttribute="centerY" secondItem="en2-KN-5t5" secondAttribute="centerY" id="KFK-DO-FJ4"/>
+                                                <constraint firstAttribute="trailing" secondItem="XFZ-5C-XeS" secondAttribute="trailing" id="TKW-BI-k2q"/>
+                                                <constraint firstItem="XFZ-5C-XeS" firstAttribute="leading" secondItem="en2-KN-5t5" secondAttribute="leading" id="ky5-sQ-DaG"/>
+                                            </constraints>
+                                        </view>
+                                    </subviews>
+                                </stackView>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rRW-J6-gEy">
+                                    <rect key="frame" x="421" y="0.0" width="57" height="334.5"/>
+                                    <connections>
+                                        <action selector="toggleDetail:" destination="-1" eventType="touchUpInside" id="ZB1-1H-aMt"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstItem="rRW-J6-gEy" firstAttribute="trailing" secondItem="XFZ-5C-XeS" secondAttribute="trailing" id="4QQ-Dr-7WD"/>
+                                <constraint firstItem="el7-Xy-oGp" firstAttribute="top" secondItem="fLN-Ja-aXc" secondAttribute="top" id="HqW-5a-7Nh"/>
+                                <constraint firstItem="el7-Xy-oGp" firstAttribute="leading" secondItem="fLN-Ja-aXc" secondAttribute="leading" id="bmb-6s-7UH"/>
+                                <constraint firstAttribute="trailing" secondItem="el7-Xy-oGp" secondAttribute="trailing" id="nEO-vF-65X"/>
+                                <constraint firstItem="rRW-J6-gEy" firstAttribute="bottom" secondItem="qiM-Ct-qfS" secondAttribute="bottom" id="skA-Ln-2wi"/>
+                                <constraint firstAttribute="bottom" secondItem="el7-Xy-oGp" secondAttribute="bottom" id="t1f-Pz-Jpi"/>
+                                <constraint firstItem="rRW-J6-gEy" firstAttribute="top" secondItem="qiM-Ct-qfS" secondAttribute="top" id="xez-UB-1ge"/>
+                                <constraint firstItem="rRW-J6-gEy" firstAttribute="leading" secondItem="qiM-Ct-qfS" secondAttribute="leading" id="zz0-SP-KQS"/>
+                            </constraints>
+                        </view>
+                        <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pqE-KU-zYT">
+                            <rect key="frame" x="0.0" y="334.5" width="478" height="69.5"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="uMp-Zy-8id">
+                                    <rect key="frame" x="0.0" y="16" width="478" height="53.5"/>
+                                    <subviews>
+                                        <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="9xW-FT-281">
+                                            <rect key="frame" x="0.0" y="0.0" width="478" height="29"/>
+                                            <segments>
+                                                <segment title=""/>
+                                                <segment title=""/>
+                                                <segment title=""/>
+                                            </segments>
+                                            <connections>
+                                                <action selector="updateSegment:" destination="-1" eventType="valueChanged" id="Evm-Z4-ZZo"/>
+                                            </connections>
+                                        </segmentedControl>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xAt-1R-IAG">
+                                            <rect key="frame" x="0.0" y="33" width="478" height="20.5"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </stackView>
+                            </subviews>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <constraints>
+                                <constraint firstAttribute="bottom" secondItem="uMp-Zy-8id" secondAttribute="bottom" id="hIi-bI-0FI"/>
+                                <constraint firstAttribute="trailing" secondItem="uMp-Zy-8id" secondAttribute="trailing" id="hVz-ih-Fc5"/>
+                                <constraint firstItem="uMp-Zy-8id" firstAttribute="top" secondItem="pqE-KU-zYT" secondAttribute="top" priority="251" constant="16" id="hfX-vK-UzN"/>
+                                <constraint firstItem="uMp-Zy-8id" firstAttribute="leading" secondItem="pqE-KU-zYT" secondAttribute="leading" id="qxb-Xy-yvl"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <constraints>
+                <constraint firstItem="tet-0s-l44" firstAttribute="top" secondItem="0uU-Pe-i9d" secondAttribute="top" id="6rU-0T-fEL"/>
+                <constraint firstItem="tet-0s-l44" firstAttribute="trailing" secondItem="0uU-Pe-i9d" secondAttribute="trailing" id="D1V-5D-tNK"/>
+                <constraint firstItem="tet-0s-l44" firstAttribute="leading" secondItem="0uU-Pe-i9d" secondAttribute="leading" id="fqZ-2G-h92"/>
+                <constraint firstAttribute="bottom" secondItem="tet-0s-l44" secondAttribute="bottom" id="gQd-A9-xyR"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="0uU-Pe-i9d"/>
+            <point key="canvasLocation" x="143.47826086956522" y="-332.14285714285711"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="icon_arrow_down_small" width="10" height="4"/>
+    </resources>
+</document>

--- a/Library/Views/OnChainFeeView/OnChainFeeView.swift
+++ b/Library/Views/OnChainFeeView/OnChainFeeView.swift
@@ -19,7 +19,7 @@ final class OnChainFeeView: UIView {
 
     @IBOutlet private weak var rightStackView: UIStackView!
     @IBOutlet private weak var titleLabel: UILabel!
-    @IBOutlet private weak var deatiledDescriptionLabel: UILabel!
+    @IBOutlet private weak var detailedDescriptionLabel: UILabel!
     @IBOutlet private weak var arrowImageView: UIImageView!
     @IBOutlet private weak var segmentedControl: UISegmentedControl!
     @IBOutlet private weak var timeIntervalLabel: UILabel!
@@ -53,7 +53,7 @@ final class OnChainFeeView: UIView {
         contentView.backgroundColor = UIColor.Zap.background
 
         Style.Label.headline.apply(to: titleLabel)
-        Style.Label.subHeadline.apply(to: deatiledDescriptionLabel, timeIntervalLabel)
+        Style.Label.subHeadline.apply(to: detailedDescriptionLabel, timeIntervalLabel)
 
         let loadingAmountView = LoadingAmountView(loadable: loadable)
         loadingAmountView.textAlignment = .right
@@ -111,6 +111,6 @@ final class OnChainFeeView: UIView {
     private func updateFeeLabels(for index: Int) {
         let tier = onChainFeeViewModel.tiers[index]
         timeIntervalLabel.text = L10n.Scene.Send.OnChain.Fee.estimatedDelivery(tier.formattedConfirmationTimeInterval)
-        deatiledDescriptionLabel.text = tier.description
+        detailedDescriptionLabel.text = tier.description
     }
 }

--- a/Library/Views/OnChainFeeView/OnChainFeeView.xib
+++ b/Library/Views/OnChainFeeView/OnChainFeeView.xib
@@ -15,7 +15,7 @@
                 <outlet property="arrowImageView" destination="XFZ-5C-XeS" id="Elg-0U-HmU"/>
                 <outlet property="bottomContainer" destination="pqE-KU-zYT" id="CDz-kq-8ES"/>
                 <outlet property="contentView" destination="D6e-Lh-374" id="4uI-Qa-Oxw"/>
-                <outlet property="deatiledDescriptionLabel" destination="fhb-Mj-tO3" id="1dV-ml-hXg"/>
+                <outlet property="detailedDescriptionLabel" destination="fhb-Mj-tO3" id="1dV-ml-hXg"/>
                 <outlet property="rightStackView" destination="qiM-Ct-qfS" id="tfh-Ks-acA"/>
                 <outlet property="segmentedControl" destination="9xW-FT-281" id="iCd-Hp-4tl"/>
                 <outlet property="timeIntervalLabel" destination="xAt-1R-IAG" id="uGf-Y8-Lir"/>

--- a/Library/en.lproj/Localizable.strings
+++ b/Library/en.lproj/Localizable.strings
@@ -99,6 +99,8 @@
 "scene.open_channel.subtitle.minimum_size" = "Minimum channel size: %@";
 "scene.open_channel.subtitle.maximum_size" = "Maximum channel size: %@";
 "scene.open_channel.subtitle.balance" = "On-chain balance: %@";
+"scene.open_channel.priority" = "Priority:";
+"scene.open_channel.estimated-confirmation-time" = "Estimated confimation time: %@";
 "scene.open_channel.suggested_peers.title" = "Suggested Peers";
 "scene.open_channel.paste_button.title" = "Paste Peer Address";
 

--- a/Lightning/Services/ChannelService.swift
+++ b/Lightning/Services/ChannelService.swift
@@ -64,24 +64,24 @@ public final class ChannelService {
         }
     }
 
-    public func open(lightningNodeURI: LightningNodeURI, amount: Satoshi, completion: @escaping ApiCompletion<ChannelPoint>) {
+    public func open(lightningNodeURI: LightningNodeURI, amount: Satoshi, confirmationTarget: Int, completion: @escaping ApiCompletion<ChannelPoint>) {
         api.peers { [weak self, api] result in
             if (try? result.get())?.contains(where: { $0.pubKey == lightningNodeURI.pubKey }) == true {
-                self?.openConnectedChannel(pubKey: lightningNodeURI.pubKey, amount: amount, completion: completion)
+                self?.openConnectedChannel(pubKey: lightningNodeURI.pubKey, amount: amount, confirmationTarget: confirmationTarget, completion: completion)
             } else {
                 api.connect(pubKey: lightningNodeURI.pubKey, host: lightningNodeURI.host) { result in
                     if case .failure(let error) = result {
                         completion(.failure(LndApiError.localizedError(error.localizedDescription)))
                     } else {
-                        self?.openConnectedChannel(pubKey: lightningNodeURI.pubKey, amount: amount, completion: completion)
+                        self?.openConnectedChannel(pubKey: lightningNodeURI.pubKey, amount: amount, confirmationTarget: confirmationTarget, completion: completion)
                     }
                 }
             }
         }
     }
 
-    private func openConnectedChannel(pubKey: String, amount: Satoshi, completion: @escaping ApiCompletion<ChannelPoint>) {
-        api.openChannel(pubKey: pubKey, amount: amount) { [channelListUpdater] in
+    private func openConnectedChannel(pubKey: String, amount: Satoshi, confirmationTarget: Int, completion: @escaping ApiCompletion<ChannelPoint>) {
+        api.openChannel(pubKey: pubKey, amount: amount, confirmationTarget: confirmationTarget) { [channelListUpdater] in
             channelListUpdater.update()
             completion($0)
         }

--- a/SwiftLnd/Api/LightningApi.swift
+++ b/SwiftLnd/Api/LightningApi.swift
@@ -59,8 +59,8 @@ public final class LightningApi {
         connection.getInfo(Lnrpc_GetInfoRequest(), completion: run(completion, map: Info.init))
     }
 
-    public func openChannel(pubKey: String, amount: Satoshi, completion: @escaping ApiCompletion<ChannelPoint>) {
-        let request = Lnrpc_OpenChannelRequest(pubKey: pubKey, amount: amount)
+    public func openChannel(pubKey: String, amount: Satoshi, confirmationTarget: Int, completion: @escaping ApiCompletion<ChannelPoint>) {
+        let request = Lnrpc_OpenChannelRequest(pubKey: pubKey, amount: amount, targetConf: confirmationTarget)
         connection.openChannelSync(request, completion: run(completion, map: ChannelPoint.init))
     }
 

--- a/SwiftLnd/Extensions/Protobuf+Extensions.swift
+++ b/SwiftLnd/Extensions/Protobuf+Extensions.swift
@@ -71,6 +71,11 @@ extension Lnrpc_OpenChannelRequest {
         localFundingAmount = amount.int64
         `private` = true
     }
+
+    init(pubKey: String, amount: Satoshi, targetConf: Int) {
+        self.init(pubKey: pubKey, amount: amount)
+        self.targetConf = Int32(targetConf)
+    }
 }
 
 extension Lnrpc_SendCoinsRequest {

--- a/Zap.xcodeproj/project.pbxproj
+++ b/Zap.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		1A7D437F09C2E9CB2A9B7823 /* Pods_SnapshotUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCA0C98DE37497981C015AC5 /* Pods_SnapshotUITests.framework */; };
 		391FC6E65BB7824B7A174682 /* Pods_LibraryTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9FDBEC0089BCC09D314B328 /* Pods_LibraryTests.framework */; };
 		3FCED3EA112663089C273764 /* *.bitcoinaverage.com.cer in Resources */ = {isa = PBXBuildFile; fileRef = 3FCED45A10ACE912173010E1 /* *.bitcoinaverage.com.cer */; };
+		3FCEDBC333E5A5EDDDADF308 /* ChannelFeePriorityView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 3FCEDAA3AB01C13F1E239FB3 /* ChannelFeePriorityView.xib */; };
+		3FCEDBE9C84CF283ADCE022C /* ChannelFeePriorityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FCED05B4746839E18C6051C /* ChannelFeePriorityView.swift */; };
 		40421D49C6A596EC2CB5C295 /* Pods_RPC_Widget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2726BC721E26EB865EC5F682 /* Pods_RPC_Widget.framework */; };
 		429230B451D7CAF7718C5EBB /* Pods_RPC_SwiftLnd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D1D7DC8244C0E3E65FCB72FA /* Pods_RPC_SwiftLnd.framework */; };
 		508C114BE3C2C3584AB55069 /* Pods_LightningTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 64689AAAE184A2256E9C9DF3 /* Pods_LightningTests.framework */; };
@@ -511,7 +513,9 @@
 		33E251D96B1C9CCCBC786874 /* Pods-RPC-Widget.debugremote.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RPC-Widget.debugremote.xcconfig"; path = "Pods/Target Support Files/Pods-RPC-Widget/Pods-RPC-Widget.debugremote.xcconfig"; sourceTree = "<group>"; };
 		368878AB4DD1935EDBB4639B /* Pods-SnapshotUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SnapshotUITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SnapshotUITests/Pods-SnapshotUITests.release.xcconfig"; sourceTree = "<group>"; };
 		39F0AC8A86ACCF0C7BBB6779 /* Pods-RPC-Widget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RPC-Widget.release.xcconfig"; path = "Pods/Target Support Files/Pods-RPC-Widget/Pods-RPC-Widget.release.xcconfig"; sourceTree = "<group>"; };
+		3FCED05B4746839E18C6051C /* ChannelFeePriorityView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChannelFeePriorityView.swift; sourceTree = "<group>"; };
 		3FCED45A10ACE912173010E1 /* *.bitcoinaverage.com.cer */ = {isa = PBXFileReference; lastKnownFileType = file.cer; path = "*.bitcoinaverage.com.cer"; sourceTree = "<group>"; };
+		3FCEDAA3AB01C13F1E239FB3 /* ChannelFeePriorityView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ChannelFeePriorityView.xib; sourceTree = "<group>"; };
 		4629437540BC6CE36F3EE098 /* Pods_RPC_Library.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RPC_Library.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A29C2D527BF19A41F251C3F /* Pods_Zap.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Zap.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4AE4B3957AC31DDABB89AF3B /* Pods-RPC-SwiftLnd.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RPC-SwiftLnd.release.xcconfig"; path = "Pods/Target Support Files/Pods-RPC-SwiftLnd/Pods-RPC-SwiftLnd.release.xcconfig"; sourceTree = "<group>"; };
@@ -1114,6 +1118,15 @@
 			path = bitcoinaverage.com;
 			sourceTree = "<group>";
 		};
+		6A330F8522AD4E5D00749948 /* ChannelFeePriortyView */ = {
+			isa = PBXGroup;
+			children = (
+				3FCEDAA3AB01C13F1E239FB3 /* ChannelFeePriorityView.xib */,
+				3FCED05B4746839E18C6051C /* ChannelFeePriorityView.swift */,
+			);
+			path = ChannelFeePriortyView;
+			sourceTree = "<group>";
+		};
 		A01009322014BD960001EF94 /* Scenes */ = {
 			isa = PBXGroup;
 			children = (
@@ -1164,6 +1177,7 @@
 		A010093E2014D4720001EF94 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				6A330F8522AD4E5D00749948 /* ChannelFeePriortyView */,
 				AD1831C32296855200120260 /* OnChainFeeView */,
 				ADBA120720935871001F7700 /* AmountInput */,
 				AD21768820C3DFDB007779DE /* BalanceView.swift */,
@@ -2609,6 +2623,7 @@
 				ADA2DD07225CDD03007482D9 /* SuggestedPeerCell.xib in Resources */,
 				ADEEB53821346DEA00D2F992 /* ModalPin.storyboard in Resources */,
 				AD391CDA20D16FE1007EE22A /* History.storyboard in Resources */,
+				3FCEDBC333E5A5EDDDADF308 /* ChannelFeePriorityView.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3294,6 +3309,7 @@
 				AD391C2B20D16EFA007EE22A /* SignalProtocol.swift in Sources */,
 				ADF232D42289A08100CB5053 /* Migrations.swift in Sources */,
 				ADDD13B92119CEB40035D2F9 /* UIStackView.swift in Sources */,
+				3FCEDBE9C84CF283ADCE022C /* ChannelFeePriorityView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Heavily inspired (read: copy pasted) from the new fee selector in send payment. LND is unable to provide a fee estimate because we don't have a target address. We can however use the target confirmation time to have LND set an appropriate fee for the transaction. 

Partly fixes: https://github.com/LN-Zap/zap-iOS/issues/146

## Description
1. I made new fee view without the fee estimate and spinner
2. Added this view to the Open Channel Scene
3. Modified open channel to pass down target confirmation time

## Motivation and Context
I'm a cheap bastard - so opening channels at spot price for next block is too expensive 😬

## How Has This Been Tested?
I've tested it on my phone. Seems to be working 🚀 

## Screenshots (if appropriate):
![IMG_1381](https://user-images.githubusercontent.com/1461461/59162188-2f7b4200-8aed-11e9-87fa-f85cf691dd97.jpg)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
