### PR TITLE
useMissionControl for all Lnrpc_QueryRoutesRequest

### DIFF
--- a/SwiftLnd/Extensions/Protobuf+Extensions.swift
+++ b/SwiftLnd/Extensions/Protobuf+Extensions.swift
@@ -119,6 +119,7 @@ extension Lnrpc_QueryRoutesRequest {
 
         pubKey = destination
         amt = amount.int64
+        useMissionControl = true
     }
 }
 


### PR DESCRIPTION
## Description
Using the extension for `Lnrpc_QueryRoutesRequest` I set the `useMissionControl` on all initializations of the `Lnrpc_QueryRoutesRequest` to `true`.

## Motivation and Context
This solves issue #275 which allows lightning payments to use the optimal route as determined by Mission Control.

## How Has This Been Tested?
On testnet I opened a channel to lnd.fun (0260d9119979caedc570ada883ff614c6efb93f7f7382e25d73ecbeba0b62df2d7@lnd.fun:9735. [lnd.fun](http://lnd.fun/pendinginvoices) lists pending invoices which I was able to copy a few pending invoices from and try sending them payments. When the request was created I set a breakpoint in the code to see which variables were set on the `Lnrpc_QueryRoutesRequest` since this is a low-level change and no distinct difference is made to the user in the UI. Each time I tried sending a lightning payment `useMissionControl` was set to `true` for the request.

## Screenshots (if appropriate):
<img width="1726" alt="Screen Shot 2019-10-11 at 7 40 19 AM" src="https://user-images.githubusercontent.com/1864955/66654026-eb18c380-ebfe-11e9-925c-dd11386cf4a1.png">
<img width="584" alt="Screen Shot 2019-10-11 at 7 40 22 AM" src="https://user-images.githubusercontent.com/1864955/66654027-eb18c380-ebfe-11e9-8ccf-16a4b593b79b.png">
<img width="584" alt="Screen Shot 2019-10-11 at 7 40 37 AM" src="https://user-images.githubusercontent.com/1864955/66654028-ebb15a00-ebfe-11e9-9837-695b6e1e302c.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
