### PR TITLE
Fixing Empty State Popup

### DIFF
--- a/Library/Scenes/ChannelList/ChannelListViewModel.swift
+++ b/Library/Scenes/ChannelList/ChannelListViewModel.swift
@@ -56,22 +56,22 @@ final class ChannelListViewModel: NSObject {
 
     init(lightningService: LightningService) {
         self.lightningService = lightningService
+        self.dataSource = MutableObservableArray()
 
-        dataSource = MutableObservableArray()
-
-        shouldHideEmptyWalletState = lightningService.balanceService.onChainTotal
+        self.shouldHideEmptyWalletState = lightningService.balanceService.totalBalance
             .map { $0 > 0 }
+            .distinctUntilChanged()
 
-        shouldHideChannelListEmptyState = combineLatest(lightningService.balanceService.onChainTotal, dataSource)
+        self.shouldHideChannelListEmptyState = combineLatest(lightningService.balanceService.onChainTotal, dataSource)
             .map { $0 <= 0 || !$1.collection.isEmpty }
             .distinctUntilChanged()
 
-        shouldShowBadgeIcon = combineLatest(lightningService.balanceService.onChainConfirmed, dataSource)
-                .map { $0 > 0 && $1.collection.isEmpty }
-                .distinctUntilChanged()
+        self.shouldShowBadgeIcon = combineLatest(lightningService.balanceService.onChainConfirmed, dataSource)
+            .map { $0 > 0 && $1.collection.isEmpty }
+            .distinctUntilChanged()
 
         super.init()
-
+        
         combineLatest(channelService.open, channelService.pending)
             .observeOn(DispatchQueue.main)
             .observeNext { [weak self] in

--- a/Library/Scenes/Wallet/WalletViewController.swift
+++ b/Library/Scenes/Wallet/WalletViewController.swift
@@ -132,8 +132,7 @@ final class WalletViewController: UIViewController {
         let emptyStateView = EmptyStateView(viewModel: emptyStateViewModel)
         emptyStateView.add(to: view)
 
-        walletViewModel.totalBalance
-            .map { $0 > 0 }
+        walletViewModel.shouldHideEmptyWalletState
             .bind(to: emptyStateView.reactive.isHidden)
             .dispose(in: reactive.bag)
     }
@@ -171,7 +170,7 @@ final class WalletViewController: UIViewController {
 
     private func setupPrimaryBalanceLabel() {
         ReactiveKit
-            .combineLatest(walletViewModel.totalBalance, Settings.shared.primaryCurrency) { satoshis, currency -> NSAttributedString? in
+            .combineLatest(walletViewModel.lightningService.balanceService.totalBalance, Settings.shared.primaryCurrency) { satoshis, currency -> NSAttributedString? in
                 if let bitcoin = currency as? Bitcoin {
                     return bitcoin.attributedFormat(satoshis: satoshis)
                 } else {
@@ -186,7 +185,7 @@ final class WalletViewController: UIViewController {
 
     private func setupBindings() {
         [
-            walletViewModel.totalBalance
+            walletViewModel.lightningService.balanceService.totalBalance
                 .distinctUntilChanged()
                 .bind(to: secondaryBalanceLabel.reactive.text, currency: Settings.shared.secondaryCurrency),
             walletViewModel.circleGraphSegments

--- a/Lightning/Services/BalanceService.swift
+++ b/Lightning/Services/BalanceService.swift
@@ -11,7 +11,7 @@ import ReactiveKit
 import SwiftBTC
 import SwiftLnd
 
-public final class BalanceService {
+public final class BalanceService: NSObject {
     private let api: LightningApi
 
     public let onChainConfirmed = Observable<Satoshi>(0)
@@ -22,14 +22,25 @@ public final class BalanceService {
 
     public let onChainTotal = Observable<Satoshi>(0)
     public let totalPending: Signal<Satoshi, Never>
+    
+    public let totalBalance = Observable<Satoshi>(0)
 
     // sum of funds stuck in force closing channels, set from `ChannelListUpdater`
     public let forceCloseLimboBalance = Observable<Satoshi>(0)
 
     init(api: LightningApi) {
         self.api = api
-
-        totalPending = combineLatest(onChainUnconfirmed, lightningPendingOpenBalance, forceCloseLimboBalance) { $0 + $1 + $2 }
+        self.totalPending = combineLatest(onChainUnconfirmed, lightningPendingOpenBalance, forceCloseLimboBalance) { $0 + $1 + $2 }
+        
+        super.init()
+        
+        combineLatest(lightningChannelBalance, onChainConfirmed, totalPending)
+            .distinctUntilChanged { $0 != $1 }
+            .observeNext { [weak self] in
+                let (lightningBalance, onChainBalance, pendingBalance) = $0
+                
+                self?.totalBalance.value = lightningBalance + onChainBalance + pendingBalance
+        }.dispose(in: reactive.bag)
     }
 
     func update() {

--- a/Lightning/Services/BalanceService.swift
+++ b/Lightning/Services/BalanceService.swift
@@ -40,7 +40,7 @@ public final class BalanceService: NSObject {
                 let (lightningBalance, onChainBalance, pendingBalance) = $0
                 
                 self?.totalBalance.value = lightningBalance + onChainBalance + pendingBalance
-        }.dispose(in: reactive.bag)
+            }.dispose(in: reactive.bag)
     }
 
     func update() {


### PR DESCRIPTION
## Description
I moved the `totalBalance` calculation into the `BalanceService` since it seemed like the more natural fit. Now both the `ChannelListViewModel` and `WalletViewModel` can leverage that signal calculation and `Observable` in order to properly update their own state and underlying UI.

## Motivation and Context
This change addresses issue #276.

## How Has This Been Tested?
The first test was with a wallet that had both on chain and lightning channel funds on testnet. I transferred all of the on chain funds out of the wallet and no longer was seeing the popup to "add funds to my wallet." The next test was with a brand new wallet. I created a brand new wallet on testnet and let it fully sync to the blockchain. At this point I was seeing the popup to "add funds to my wallet." I then transferred some sats into my on chain wallet while the app was open and the Channels page was active. As soon as the blockchain processed the block with my transactions I no longer saw the popup to "add funds to my wallet."

## Screenshots (if appropriate):
<img width="584" alt="Screen Shot 2019-10-15 at 8 41 26 PM" src="https://user-images.githubusercontent.com/1864955/66881475-8d80d000-ef8c-11e9-8787-b0e16cb5827c.png">
<img width="584" alt="Screen Shot 2019-10-15 at 8 41 29 PM" src="https://user-images.githubusercontent.com/1864955/66881476-8d80d000-ef8c-11e9-92a4-93d41c2ea534.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
