### PR TITLE
fix: Debouncing Sync View

### DIFF
--- a/Library/Scenes/Wallet/WalletViewController.swift
+++ b/Library/Scenes/Wallet/WalletViewController.swift
@@ -140,6 +140,7 @@ final class WalletViewController: UIViewController {
     private func setupSyncView() {
         walletViewModel.syncViewModel.isSyncing
             .map { $0 ? UILayoutPriority(rawValue: 1) : UILayoutPriority(rawValue: 999) }
+            .debounce(interval: 2)
             .observeOn(DispatchQueue.main)
             .observeNext { [weak self] in
                 self?.syncViewHeightConstraint.priority = $0


### PR DESCRIPTION
## Description
I added a debounce of 2 seconds to the displaying of the sync view. This prevents a situation where there are 0-1 blocks that need to be synced and the sync view shows unnecessarily. I also added some logic so that the main page is not reloaded twice unnecessarily when switching between similar states.

## Motivation and Context
This addresses issue #227 

## How Has This Been Tested?
The easiest way to test this was by opening and closing the app rapidly. By rapidly I mean opening the app, waiting 10 seconds and then closing the app. I did this quite a few times in a row and each time I was not seeing the sync view.

The other scenario I tested was the initial sync of the blockchain by creating a new wallet or recovering an existing wallet. Both scenarios showed the sync view in an appropriate amount of time and then concluded the sync as expected, hiding the sync view, showing the correct balance on the wallet page and badges within the tabs.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
