### PR TITLE
Error messaging for send amount too small

### DIFF
--- a/Library/Generated/strings.swift
+++ b/Library/Generated/strings.swift
@@ -533,6 +533,8 @@ internal enum L10n {
       internal static let memoHeadline = L10n.tr("Localizable", "scene.send.memo_headline")
       /// Send
       internal static let sendButton = L10n.tr("Localizable", "scene.send.send_button")
+      /// Send amount too small
+      internal static let sendAmountTooSmall = L10n.tr("Localizable", "scene.send.send_amount_too_small")
       /// Sending...
       internal static let sending = L10n.tr("Localizable", "scene.send.sending")
       /// Payment Successful

--- a/Library/Generated/strings.swift
+++ b/Library/Generated/strings.swift
@@ -535,8 +535,6 @@ internal enum L10n {
       internal static let sendButton = L10n.tr("Localizable", "scene.send.send_button")
       /// Send amount too small
       internal static let sendAmountTooSmall = L10n.tr("Localizable", "scene.send.send_amount_too_small")
-      /// Send amount too small for estimate
-      internal static let sendAmountTooSmallForEstimate = L10n.tr("Localizable", "scene.send.send_amount_too_small_for_estimate")
       /// Sending...
       internal static let sending = L10n.tr("Localizable", "scene.send.sending")
       /// Payment Successful

--- a/Library/Generated/strings.swift
+++ b/Library/Generated/strings.swift
@@ -535,6 +535,8 @@ internal enum L10n {
       internal static let sendButton = L10n.tr("Localizable", "scene.send.send_button")
       /// Send amount too small
       internal static let sendAmountTooSmall = L10n.tr("Localizable", "scene.send.send_amount_too_small")
+      /// Send amount too small for estimate
+      internal static let sendAmountTooSmallForEstimate = L10n.tr("Localizable", "scene.send.send_amount_too_small_for_estimate")
       /// Sending...
       internal static let sending = L10n.tr("Localizable", "scene.send.sending")
       /// Payment Successful

--- a/Library/Scenes/ModalDetail/Send/LoadingAmountView.swift
+++ b/Library/Scenes/ModalDetail/Send/LoadingAmountView.swift
@@ -16,6 +16,21 @@ enum Loadable<E> {
     case element(E)
 }
 
+enum LoadingError: Error, Equatable {
+    case invalidFee
+    case lndApiError(LndApiError)
+    case unknownError
+    
+    public init(error: Error) {
+        switch error {
+        case is LndApiError:
+            self = .lndApiError(error as! LndApiError) // swiftlint:disable:this force_cast
+        default:
+            self = .unknownError
+        }
+    }
+}
+
 final class LoadingAmountView: UIView {
     let amountLabel: UILabel
     let activityIndicator: UIActivityIndicatorView
@@ -30,7 +45,7 @@ final class LoadingAmountView: UIView {
         }
     }
 
-    init(loadable: Observable<Loadable<Result<Satoshi, LndApiError>>>) {
+    init(loadable: Observable<Loadable<Result<Satoshi, LoadingError>>>) {
         amountLabel = UILabel(frame: CGRect.zero)
         activityIndicator = UIActivityIndicatorView(style: .white)
 
@@ -64,7 +79,7 @@ final class LoadingAmountView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func updateLoadable(_ loadable: Loadable<Result<Satoshi, LndApiError>>) {
+    private func updateLoadable(_ loadable: Loadable<Result<Satoshi, LoadingError>>) {
         switch loadable {
         case .loading:
             activityIndicator.isHidden = false

--- a/Library/Scenes/ModalDetail/Send/LoadingAmountView.swift
+++ b/Library/Scenes/ModalDetail/Send/LoadingAmountView.swift
@@ -9,10 +9,12 @@ import Bond
 import Foundation
 import ReactiveKit
 import SwiftBTC
+import SwiftLnd
 
-enum Loadable<E> {
+enum Loadable<T, E> {
     case loading
-    case element(E)
+    case element(T)
+    case error(E)
 }
 
 final class LoadingAmountView: UIView {
@@ -29,7 +31,7 @@ final class LoadingAmountView: UIView {
         }
     }
 
-    init(loadable: Observable<Loadable<Satoshi?>>) {
+    init(loadable: Observable<Loadable<Satoshi?, LndApiError>>) {
         amountLabel = UILabel(frame: CGRect.zero)
         activityIndicator = UIActivityIndicatorView(style: .white)
 
@@ -63,7 +65,7 @@ final class LoadingAmountView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func updateLoadable(_ loadable: Loadable<Satoshi?>) {
+    private func updateLoadable(_ loadable: Loadable<Satoshi?, LndApiError>) {
         switch loadable {
         case .loading:
             activityIndicator.isHidden = false
@@ -80,8 +82,16 @@ final class LoadingAmountView: UIView {
             } else {
                 amountLabel.text = "-"
             }
-
+        case .error(let lndApiError):
+            activityIndicator.isHidden = true
+            amountLabel.isHidden = false
+            let dustErrorString = "rpc error: code = Unknown desc = transaction output is dust"
+            
+            if lndApiError.localizedDescription == dustErrorString {
+                amountLabel.text = L10n.Scene.Send.sendAmountTooSmall
+            } else {
+                amountLabel.text = "-"
+            }
         }
-
     }
 }

--- a/Library/Scenes/ModalDetail/Send/LoadingAmountView.swift
+++ b/Library/Scenes/ModalDetail/Send/LoadingAmountView.swift
@@ -85,11 +85,11 @@ final class LoadingAmountView: UIView {
         case .error(let lndApiError):
             activityIndicator.isHidden = true
             amountLabel.isHidden = false
-            let dustErrorString = "rpc error: code = Unknown desc = transaction output is dust"
             
-            if lndApiError.localizedDescription == dustErrorString {
-                amountLabel.text = L10n.Scene.Send.sendAmountTooSmall
-            } else {
+            switch lndApiError {
+            case .transactionDust:
+                amountLabel.text = L10n.Scene.Send.sendAmountTooSmallForEstimate
+            default:
                 amountLabel.text = "-"
             }
         }

--- a/Library/Scenes/ModalDetail/Send/LoadingAmountView.swift
+++ b/Library/Scenes/ModalDetail/Send/LoadingAmountView.swift
@@ -82,16 +82,11 @@ final class LoadingAmountView: UIView {
             } else {
                 amountLabel.text = "-"
             }
-        case .error(let lndApiError):
+        case .error:
             activityIndicator.isHidden = true
             amountLabel.isHidden = false
             
-            switch lndApiError {
-            case .transactionDust:
-                amountLabel.text = L10n.Scene.Send.sendAmountTooSmallForEstimate
-            default:
-                amountLabel.text = "-"
-            }
+            amountLabel.text = "-"
         }
     }
 }

--- a/Library/Scenes/ModalDetail/Send/SendViewModel.swift
+++ b/Library/Scenes/ModalDetail/Send/SendViewModel.swift
@@ -48,7 +48,7 @@ final class SendViewModel: NSObject {
         }
     }
 
-    let fee = Observable<Loadable<Result<Satoshi, LndApiError>>>(.loading)
+    let fee = Observable<Loadable<Result<Satoshi, LoadingError>>>(.loading)
 
     let method: SendMethod
 
@@ -204,7 +204,7 @@ final class SendViewModel: NSObject {
                 }
             case .failure(let lndApiError):
                 self.isTransactionDust = lndApiError == .transactionDust
-                self.fee.value = amount > 0 ? .element(.failure(lndApiError)) : .element(.failure(.invalidFee))
+                self.fee.value = amount > 0 ? .element(.failure(LoadingError(error: lndApiError))) : .element(.failure(.invalidFee))
                 self.updateIsUIEnabled()
             }
         }

--- a/Library/Scenes/ModalDetail/Send/SendViewModel.swift
+++ b/Library/Scenes/ModalDetail/Send/SendViewModel.swift
@@ -187,27 +187,20 @@ final class SendViewModel: NSObject {
         guard let amount = amount else { return }
 
         let feeCompletion = { [weak self] (result: Result<(amount: Satoshi, fee: Satoshi?), LndApiError>) -> Void in
+            guard
+                let self = self
+                else { return }
             switch result {
             case .success(let result):
                 guard
-                    let self = self,
                     result.amount == self.amount
                     else { return }
                 
                 self.isTransactionDust = false
                 self.fee.value = .element(result.fee)
             case .failure(let lndApiError):
-                guard
-                    let self = self
-                    else { return }
-                
-                if lndApiError == LndApiError.transactionDust {
-                    self.isTransactionDust = true
-                } else {
-                    self.isTransactionDust = false
-                }
-                
-                self.fee.value = .error(lndApiError)
+                self.isTransactionDust = lndApiError == .transactionDust
+                self.fee.value = amount > 0 ? .error(lndApiError) : .element(nil)
                 self.updateIsUIEnabled()
             }
         }

--- a/Library/Scenes/ModalDetail/Send/SendViewModel.swift
+++ b/Library/Scenes/ModalDetail/Send/SendViewModel.swift
@@ -52,7 +52,7 @@ final class SendViewModel: NSObject {
 
     let method: SendMethod
 
-    let subtitleText = Observable<String?>(L10n.Scene.Send.sendAmountTooSmall)
+    let subtitleText = Observable<String?>(nil)
     let isSubtitleTextWarning = Observable(false)
 
     var amount: Satoshi? {

--- a/Library/Views/OnChainFeeView/OnChainFeeView.swift
+++ b/Library/Views/OnChainFeeView/OnChainFeeView.swift
@@ -36,7 +36,7 @@ final class OnChainFeeView: UIView {
 
     weak var delegate: OnChainFeeViewDelegate?
 
-    init(loadable: Observable<Loadable<Result<Satoshi, LndApiError>>>) {
+    init(loadable: Observable<Loadable<Result<Satoshi, LoadingError>>>) {
         super.init(frame: .zero)
         setup(loadable: loadable)
     }
@@ -45,7 +45,7 @@ final class OnChainFeeView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func setup(loadable: Observable<Loadable<Result<Satoshi, LndApiError>>>) {
+    private func setup(loadable: Observable<Loadable<Result<Satoshi, LoadingError>>>) {
         Bundle.library.loadNibNamed("OnChainFeeView", owner: self, options: nil)
         addSubview(contentView)
         contentView.frame = self.bounds

--- a/Library/Views/OnChainFeeView/OnChainFeeView.swift
+++ b/Library/Views/OnChainFeeView/OnChainFeeView.swift
@@ -8,6 +8,7 @@
 import Bond
 import Foundation
 import SwiftBTC
+import SwiftLnd
 
 protocol OnChainFeeViewDelegate: class {
     func confirmationTargetChanged(to confirmationTarget: Int)
@@ -35,7 +36,7 @@ final class OnChainFeeView: UIView {
 
     weak var delegate: OnChainFeeViewDelegate?
 
-    init(loadable: Observable<Loadable<Satoshi?>>) {
+    init(loadable: Observable<Loadable<Satoshi?, LndApiError>>) {
         super.init(frame: .zero)
         setup(loadable: loadable)
     }
@@ -44,7 +45,7 @@ final class OnChainFeeView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func setup(loadable: Observable<Loadable<Satoshi?>>) {
+    private func setup(loadable: Observable<Loadable<Satoshi?, LndApiError>>) {
         Bundle.library.loadNibNamed("OnChainFeeView", owner: self, options: nil)
         addSubview(contentView)
         contentView.frame = self.bounds

--- a/Library/Views/OnChainFeeView/OnChainFeeView.swift
+++ b/Library/Views/OnChainFeeView/OnChainFeeView.swift
@@ -36,7 +36,7 @@ final class OnChainFeeView: UIView {
 
     weak var delegate: OnChainFeeViewDelegate?
 
-    init(loadable: Observable<Loadable<Satoshi?, LndApiError>>) {
+    init(loadable: Observable<Loadable<Result<Satoshi, LndApiError>>>) {
         super.init(frame: .zero)
         setup(loadable: loadable)
     }
@@ -45,7 +45,7 @@ final class OnChainFeeView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func setup(loadable: Observable<Loadable<Satoshi?, LndApiError>>) {
+    private func setup(loadable: Observable<Loadable<Result<Satoshi, LndApiError>>>) {
         Bundle.library.loadNibNamed("OnChainFeeView", owner: self, options: nil)
         addSubview(contentView)
         contentView.frame = self.bounds

--- a/Library/en.lproj/Localizable.strings
+++ b/Library/en.lproj/Localizable.strings
@@ -145,6 +145,7 @@
 "scene.send.address_headline" = "To:";
 "scene.send.memo_headline" = "Memo:";
 "scene.send.sending" = "Sending...";
+"scene.send.send_amount_too_small" = "Send amount too small for fee estimation";
 "scene.send.lightning.title" = "Send Lightning Payment";
 "scene.send.on_chain.title" = "Send On-Chain";
 "scene.send.on_chain.fee" = "Fee:";

--- a/Library/en.lproj/Localizable.strings
+++ b/Library/en.lproj/Localizable.strings
@@ -146,7 +146,6 @@
 "scene.send.memo_headline" = "Memo:";
 "scene.send.sending" = "Sending...";
 "scene.send.send_amount_too_small" = "Send amount too small";
-"scene.send.send_amount_too_small_for_estimate" = "Send amount too small for fee estimation";
 "scene.send.lightning.title" = "Send Lightning Payment";
 "scene.send.on_chain.title" = "Send On-Chain";
 "scene.send.on_chain.fee" = "Fee:";

--- a/Library/en.lproj/Localizable.strings
+++ b/Library/en.lproj/Localizable.strings
@@ -145,7 +145,8 @@
 "scene.send.address_headline" = "To:";
 "scene.send.memo_headline" = "Memo:";
 "scene.send.sending" = "Sending...";
-"scene.send.send_amount_too_small" = "Send amount too small for fee estimation";
+"scene.send.send_amount_too_small" = "Send amount too small";
+"scene.send.send_amount_too_small_for_estimate" = "Send amount too small for fee estimation";
 "scene.send.lightning.title" = "Send Lightning Payment";
 "scene.send.on_chain.title" = "Send On-Chain";
 "scene.send.on_chain.fee" = "Fee:";

--- a/SwiftLnd/Api/Helper/LndApiError.swift
+++ b/SwiftLnd/Api/Helper/LndApiError.swift
@@ -17,7 +17,6 @@ public enum LndApiError: Error, LocalizedError, Equatable {
     case unknownError
     case walletAlreadyUnlocked
     case transactionDust
-    case invalidFee
     
     public init(callResult: CallResult) {
         switch callResult.statusCode {
@@ -47,7 +46,7 @@ public enum LndApiError: Error, LocalizedError, Equatable {
             return "Lnd does not seem to be running properly."
         case .transactionDust:
             return "Transaction amount too small."
-        case .invalidInput, .unknownError, .walletAlreadyUnlocked, .invalidFee:
+        case .invalidInput, .unknownError, .walletAlreadyUnlocked:
             return nil
         }
     }

--- a/SwiftLnd/Api/Helper/LndApiError.swift
+++ b/SwiftLnd/Api/Helper/LndApiError.swift
@@ -17,6 +17,7 @@ public enum LndApiError: Error, LocalizedError, Equatable {
     case unknownError
     case walletAlreadyUnlocked
     case transactionDust
+    case invalidFee
     
     public init(callResult: CallResult) {
         switch callResult.statusCode {
@@ -46,7 +47,7 @@ public enum LndApiError: Error, LocalizedError, Equatable {
             return "Lnd does not seem to be running properly."
         case .transactionDust:
             return "Transaction amount too small."
-        case .invalidInput, .unknownError, .walletAlreadyUnlocked:
+        case .invalidInput, .unknownError, .walletAlreadyUnlocked, .invalidFee:
             return nil
         }
     }

--- a/SwiftLnd/Api/Helper/LndApiError.swift
+++ b/SwiftLnd/Api/Helper/LndApiError.swift
@@ -16,7 +16,8 @@ public enum LndApiError: Error, LocalizedError, Equatable {
     case localizedError(String)
     case unknownError
     case walletAlreadyUnlocked
-
+    case transactionDust
+    
     public init(callResult: CallResult) {
         switch callResult.statusCode {
 
@@ -43,6 +44,8 @@ public enum LndApiError: Error, LocalizedError, Equatable {
             return "Wallet is encrypted."
         case .lndNotRunning:
             return "Lnd does not seem to be running properly."
+        case .transactionDust:
+            return "Transaction amount too small."
         case .invalidInput, .unknownError, .walletAlreadyUnlocked:
             return nil
         }

--- a/SwiftLnd/Api/Helper/RpcZapHelper.swift
+++ b/SwiftLnd/Api/Helper/RpcZapHelper.swift
@@ -29,9 +29,9 @@ final class LndCallback<T: SwiftProtobuf.Message>: NSObject, LndmobileCallbackPr
             if error.localizedDescription == "Closed" {
                 result = .walletAlreadyUnlocked
             } else if error.localizedDescription == "rpc error: code = Unknown desc = transaction output is dust" {
-                result = LndApiError.transactionDust
+                result = .transactionDust
             } else {
-                result = LndApiError.localizedError(error.localizedDescription)
+                result = .localizedError(error.localizedDescription)
             }
             completion(.failure(result))
         } else {

--- a/SwiftLnd/Api/Helper/RpcZapHelper.swift
+++ b/SwiftLnd/Api/Helper/RpcZapHelper.swift
@@ -28,6 +28,8 @@ final class LndCallback<T: SwiftProtobuf.Message>: NSObject, LndmobileCallbackPr
             let result: LndApiError
             if error.localizedDescription == "Closed" {
                 result = .walletAlreadyUnlocked
+            } else if error.localizedDescription == "rpc error: code = Unknown desc = transaction output is dust" {
+                result = LndApiError.transactionDust
             } else {
                 result = LndApiError.localizedError(error.localizedDescription)
             }


### PR DESCRIPTION
## Description
I added some error messaging to the UI when the user is trying to send an amount that is too small for the fee estimation service to estimate the fee.

I needed to allow the fee estimation completion block to return a result set that contained both the success and failure scenarios. This allows us to respond to both scenarios all the way down to the UI level in the `LoadingAmountView`. In this view, I look for a specific error message (not ideal) and then based upon that I tailor a more user-friendly message to display to the user.

I think I may have found a potential error in either our code or in the LND API where they are not properly returning errors back in the response. As far as I can tell the errors are all `Code=1` and in the `localizedDescription` they all come through as `code = Unknown`. This may be something we should report back to the LND team so they can better pass that through to the apps for error handling.

## Motivation and Context
As I have been testing the app I have been seeing that when I have a small number of sats I want to send the fee estimate was "-". This didn't make much sense to me and until I dug into the error that the API was returning I wasn't sure why that was happening. Thus, I put up this PR to make it a bit more user and noob friendly.

## How Has This Been Tested?
On testnet I was opening the send view and then typing in a small number of sats (<150 sats). I would type it out, delete it, type it again, etc... All of which would show the error string. I would then put in an amount large enough to trigger a fee estimate (>1000 sats) and the estimate would show.

## Screenshots (if appropriate):
<img width="584" alt="Screen Shot 2019-10-21 at 8 49 30 PM" src="https://user-images.githubusercontent.com/1864955/67255141-3b392680-f446-11e9-9f76-fbf6edee7cf9.png">
<img width="584" alt="Screen Shot 2019-10-21 at 8 49 35 PM" src="https://user-images.githubusercontent.com/1864955/67255142-3b392680-f446-11e9-90d7-8ae0d798303d.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
