### PR TITLE
Disabling the LND REST API

### DIFF
--- a/SwiftLnd/Lnd/LocalLndConfiguration.swift
+++ b/SwiftLnd/Lnd/LocalLndConfiguration.swift
@@ -60,6 +60,7 @@ struct LocalLndConfiguration {
                 ("debuglevel", "ATPL=debug,BRAR=debug,BTCN=info,CHDB=debug,CMGR=debug,CNCT=debug,CRTR=warn,DISC=debug,FNDG=debug,HSWC=debug,LNWL=debug,LTND=debug,NTFN=debug,PEER=info,RPCS=debug,SPHX=debug,SRVR=debug,UTXN=debug"),
                 ("no-macaroons", "1"),
                 ("nolisten", "1"),
+                ("norest", "1"),
                 ("alias", alias),
                 ("color", "#3399FF"),
                 ("maxbackoff", "2s"),


### PR DESCRIPTION
## Description
I added a new option to the local LND configuration to disable the TCP REST API for LND. This will help with network interference since different wallets will no longer try to listen on the same interface/port.

## Motivation and Context
This is to address issue #253.

## How Has This Been Tested?
I compiled the app and ran it on the iOS simulator without crashing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
