### PR TITLE
feature: displaying a warning before opening a block explorer link

### DIFF
--- a/Library/Coordinators/WalletCoordinator.swift
+++ b/Library/Coordinators/WalletCoordinator.swift
@@ -225,7 +225,7 @@ final class WalletCoordinator: NSObject, Coordinator {
         guard let network = lightningService.infoService.network.value else { return }
         do {
             guard let url = try Settings.shared.blockExplorer.value.url(network: network, code: code, type: type) else { return }
-            presentSafariViewController(for: url)
+            presentBlockExplorerWarning(for: url)
         } catch BlockExplorerError.unsupportedNetwork {
             Toast.presentError(L10n.Error.BlockExplorer.unsupportedNetwork(Settings.shared.blockExplorer.value.localized, network.localized))
         } catch {
@@ -301,6 +301,14 @@ final class WalletCoordinator: NSObject, Coordinator {
         safariViewController.preferredBarTintColor = UIColor.Zap.deepSeaBlue
         safariViewController.preferredControlTintColor = UIColor.Zap.lightningOrange
         (detailViewController ?? rootViewController).present(safariViewController, animated: true)
+    }
+    
+    private func presentBlockExplorerWarning(for url: URL) {
+        let alertController = UIAlertController.blockExplorerWarningAlertController { [weak self] in
+            guard let self = self else { return }
+            self.presentSafariViewController(for: url)
+        }
+        (detailViewController ?? rootViewController).present(alertController, animated: true)
     }
 
     private func dismissDetailViewController() {

--- a/Library/Extensions/UIAlertController.swift
+++ b/Library/Extensions/UIAlertController.swift
@@ -45,4 +45,19 @@ extension UIAlertController {
 
         return alertController
     }
+    
+    static func blockExplorerWarningAlertController(continueAction: @escaping () -> Void) -> UIAlertController {
+        let title = L10n.Scene.BlockExplorer.title
+        let message = L10n.Scene.BlockExplorer.message
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let cancelAlertAction = UIAlertAction(title: L10n.Generic.cancel, style: .cancel, handler: nil)
+
+        let continueAlertAction = UIAlertAction(title: L10n.Generic.continueString, style: .default) { _ in
+            continueAction()
+        }
+        alertController.addAction(cancelAlertAction)
+        alertController.addAction(continueAlertAction)
+
+        return alertController
+    }
 }

--- a/Library/Generated/strings.swift
+++ b/Library/Generated/strings.swift
@@ -68,6 +68,8 @@ internal enum L10n {
   internal enum Generic {
     /// Cancel
     internal static let cancel = L10n.tr("Localizable", "generic.cancel")
+    /// Continue
+    internal static let continueString = L10n.tr("Localizable", "generic.continue")
     internal enum Memo {
       /// What is this for?
       internal static let placeholder = L10n.tr("Localizable", "generic.memo.placeholder")
@@ -168,6 +170,12 @@ internal enum L10n {
   }
 
   internal enum Scene {
+    internal enum BlockExplorer {
+      /// Warning: Privacy Leak
+      internal static let title = L10n.tr("Localizable", "scene.block_explorer.title")
+      /// Looking up your own addresses on a block explorer leaks your privacy to the site operator.
+      internal static let message = L10n.tr("Localizable", "scene.block_explorer.message")
+    }
     internal enum ChannelBackup {
       /// %@ channel.backup
       internal static func cellTitle(_ p1: String) -> String {

--- a/Library/Scenes/History/Detail/EventDetailViewController.swift
+++ b/Library/Scenes/History/Detail/EventDetailViewController.swift
@@ -15,9 +15,16 @@ final class EventDetailViewController: ModalDetailViewController {
 
     init(event: HistoryEventType, presentBlockExplorer: @escaping (String, BlockExplorer.CodeType) -> Void) {
         viewModel = EventDetailViewModel(event: event)
-
         self.presentBlockExplorer = presentBlockExplorer
+        
         super.init(nibName: nil, bundle: nil)
+        
+        viewModel.blockExplorerButtonTapped.observeNext { [weak self] blockExplorerItem in
+            guard let self = self else { return }
+            self.dismiss(animated: true) {
+                self.presentBlockExplorer(blockExplorerItem.code, blockExplorerItem.type)
+            }
+        }.dispose(in: reactive.bag)
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -31,15 +38,7 @@ final class EventDetailViewController: ModalDetailViewController {
     }
 
     private func setupEvent() {
-        let configuration = viewModel.detailConfiguration(delegate: self)
+        let configuration = viewModel.detailConfiguration()
         contentStackView.set(elements: configuration)
-    }
-}
-
-extension EventDetailViewController: EventDetailViewModelDelegate {
-    func openBlockExplorer(code: String, type: BlockExplorer.CodeType) {
-        dismiss(animated: true) {
-            self.presentBlockExplorer(code, type)
-        }
     }
 }

--- a/Library/en.lproj/Localizable.strings
+++ b/Library/en.lproj/Localizable.strings
@@ -4,6 +4,7 @@
 "generic.pasteboard.invalid_address" = "Invalid Address";
 "generic.qr_code.share_button" = "Share";
 "generic.cancel" = "Cancel";
+"generic.continue" = "Continue";
 
 "link.help" = "https://docs.zaphq.io/";
 "link.help.zapconnect" = "https://docs.zaphq.io/docs-ios-remote-node-setup";
@@ -308,6 +309,9 @@
 "scene.manage_wallets.cell.local" = "local";
 "scene.manage_wallets.section_title.local" = "Local Wallet";
 "scene.manage_wallets.section_title.remote" = "Remote Wallets";
+
+"scene.block_explorer.title" = "Warning: Privacy Leak";
+"scene.block_explorer.message" = "Looking up your own addresses on a block explorer leaks your privacy to the site operator.";
 
 "scene.channel_backup.title" = "Channel Backup";
 "scene.channel_backup.cell_title" = "%@ channel.backup";


### PR DESCRIPTION
## Description
I added a new `UIAlertController` to display an alert to the user when they tap on a block explorer link. I also made a slight refactor to remove the `delegate` that is passed into `EventDetailViewModel.swift`. I replaced it with a more reactive approach to more fully embrace that style of programming within the app.

## Motivation and Context
This is to address issue #125.

## How Has This Been Tested?
On the iOS simulator, I went to the history page, tapped on a transaction and then tapped on both transaction hashes as well as addresses. I verified that the cancel button dismissed the alert in both cases. I also verified that the continue button took us to the correct block explorer page in both instances.

I also went to the channel page and tapped on the funding transactions. I verified that the cancel button dismissed the alert. I also verified that the continue button took us to the correct block explorer page.

## Screenshots (if appropriate):
<img width="584" alt="Screen Shot 2019-11-16 at 10 37 34 PM" src="https://user-images.githubusercontent.com/1864955/69003261-95ea6480-08c4-11ea-80f0-d8a4707e26d2.png">
<img width="584" alt="Screen Shot 2019-11-16 at 10 37 45 PM" src="https://user-images.githubusercontent.com/1864955/69003262-95ea6480-08c4-11ea-82be-3367212701ac.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
